### PR TITLE
[BUGFIX] Allow turbo stream requests in topwire context

### DIFF
--- a/Classes/Middleware/TopwireRendering.php
+++ b/Classes/Middleware/TopwireRendering.php
@@ -54,7 +54,7 @@ class TopwireRendering implements MiddlewareInterface
         }
         throw new InvalidContentType(
             sprintf(
-                'Turbo frame requests must return content/type "%s",%s got "%s". '
+                'Turbo frame requests must return content/type "%s"%s, got "%s". '
                 . 'Maybe forgot to add data-turbo="false" attribute for links leading to this error? '
                 . 'Alternatively you can rewrite the current URL to have a file extension',
                 self::defaultContentType,


### PR DESCRIPTION
If a turbo stream request is done in a turbo-frame, using a topwire context, an "Accept" header is sent and the response must use Content-Type `text/vnd.turbo-stream.html` instead of `text/html` so we have to allow this combination in the topwire rendering process.