### PR TITLE
[BUGFIX] Ensure "pageuid" provided by TYPO3 is an integer

### DIFF
--- a/Classes/Typolink/TopwirePageLinkModifier.php
+++ b/Classes/Typolink/TopwirePageLinkModifier.php
@@ -31,7 +31,7 @@ class TopwirePageLinkModifier implements TypolinkModifyLinkConfigForPageLinksHoo
             $pageLinkContext,
             $linkConfiguration,
             $queryParameters,
-            $linkDetails['pageuid'] ?? null
+            ($linkDetails['pageuid'] ?? null) !== null ? (int)$linkDetails['pageuid'] : null
         );
         $linkConfigurationEvent->setQueryParameters($queryParameters);
     }
@@ -55,7 +55,7 @@ class TopwirePageLinkModifier implements TypolinkModifyLinkConfigForPageLinksHoo
             $pageLinkContext,
             $linkConfiguration,
             $queryParameters,
-            $linkDetails['pageuid'] ?? null
+            ($linkDetails['pageuid'] ?? null) !== null ? (int)$linkDetails['pageuid'] : null
         );
         $linkConfiguration['additionalParams'] = '&' . HttpUtility::buildQueryString($queryParameters);
         return $linkConfiguration;


### PR DESCRIPTION
The link data provided by TYPO3 may contain the "pageuid" as string but an integer is expected. So we do now cast this value to an integer.

Resolved #21