### PR TITLE
[BUGFIX] Ensure extbase arguments are passed properly

### DIFF
--- a/Classes/ViewHelpers/Context/RenderViewHelper.php
+++ b/Classes/ViewHelpers/Context/RenderViewHelper.php
@@ -80,25 +80,15 @@ class RenderViewHelper extends AbstractViewHelper
         if (!$pageArguments instanceof PageArguments) {
             return $request;
         }
-        $extbaseArguments = [];
-        if ($request instanceof Request) {
-            $extbaseArguments = $request->getArguments();
-        }
-        $newRootArguments = array_merge(
-            $pageArguments->getRouteArguments(),
-            [
-                $plugin->pluginNamespace => array_replace(
-                    $extbaseArguments,
-                    [
-                        'action' => $plugin->actionName,
-                    ]
-                ),
-            ]
-        );
+
+        $routeArguments = $pageArguments->getRouteArguments();
+        $routeArguments[$plugin->pluginNamespace] ??= [];
+        $routeArguments[$plugin->pluginNamespace]['action'] = $plugin->actionName;
+
         $modifiedPageArguments = new PageArguments(
             $pageArguments->getPageId(),
             $pageArguments->getPageType(),
-            $newRootArguments,
+            $routeArguments,
             $pageArguments->getStaticArguments(),
             $pageArguments->getDynamicArguments()
         );


### PR DESCRIPTION
Ensure all routeArguemnts are passed properly to the topwire plugin rendering context even when routeEnhancers are used.
The $request->getArguments() can't be used if the topwire plugin rendering is not done in the same extbase plugin / controller context.

Resolves #36