### PR TITLE
[TASK] Move rendering code to page type

### DIFF
--- a/Classes/ContentObject/TopwireContentObject.php
+++ b/Classes/ContentObject/TopwireContentObject.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 class TopwireContentObject extends AbstractContentObject
 {
     public const NAME = 'TOPWIRE';
+    public const PAGE_TYPE = '1745763872';
 
     /**
      * @param array<mixed> $conf
@@ -18,6 +19,9 @@ class TopwireContentObject extends AbstractContentObject
     public function render($conf = []): string
     {
         $context = $conf['context'];
+        if ($context === 'fromRequest') {
+            $context = $this->request->getAttribute('topwire');
+        }
         assert($context instanceof TopwireContext);
         $content = $this->renderContentWithoutRecursion($context);
         $frame = $context->getAttribute('frame');

--- a/Classes/Middleware/TopwireContextResolver.php
+++ b/Classes/Middleware/TopwireContextResolver.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Topwire\ContentObject\TopwireContentObject;
 use Topwire\Context\ContextDenormalizer;
 use Topwire\Context\TopwireContext;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
@@ -34,6 +35,7 @@ class TopwireContextResolver implements MiddlewareInterface
         }
         $cacheId = $context->cacheId;
         $frame = $context->getAttribute('frame');
+        $pageType = TopwireContentObject::PAGE_TYPE;
         if ($context->contextRecord->pageId !== $pageArguments->getPageId()) {
             // Crossing page boundaries happen, when the controller returns a redirect response
             // In this case, the context is invalid, needs to be reset and a full page render must happen
@@ -48,6 +50,7 @@ class TopwireContextResolver implements MiddlewareInterface
             // around, to allow elements on the target page with the same id show up, while keep them
             // hidden on a regular request.
             $context = null;
+            $pageType = '0';
         }
         $newStaticArguments = array_merge(
             $pageArguments->getStaticArguments(),
@@ -57,7 +60,7 @@ class TopwireContextResolver implements MiddlewareInterface
         );
         $modifiedPageArguments = new PageArguments(
             $pageArguments->getPageId(),
-            $pageArguments->getPageType(),
+            $pageType,
             $pageArguments->getRouteArguments(),
             $newStaticArguments,
             $pageArguments->getDynamicArguments()

--- a/Classes/Middleware/TopwireRendering.php
+++ b/Classes/Middleware/TopwireRendering.php
@@ -5,10 +5,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Topwire\ContentObject\TopwireContentObject;
-use Topwire\Context\TopwireContext;
 use Topwire\Exception\InvalidContentType;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * Lightweight alternative to regular frontend requests, rendering only the provided context record/ plugin
@@ -20,28 +17,7 @@ class TopwireRendering implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $frontendController = $request->getAttribute('frontend.controller');
-        assert($frontendController instanceof TypoScriptFrontendController);
-        $context = $request->getAttribute('topwire');
-        if (!$context instanceof TopwireContext || !$frontendController->isGeneratePage()) {
-            return $this->validateContentType($request, $handler->handle($request));
-        }
-
-        $frontendController->config['config']['debug'] = 0;
-        $frontendController->config['config']['disableAllHeaderCode'] = 1;
-        $frontendController->config['config']['disableCharsetHeader'] = 0;
-        $frontendController->pSetup = [
-            '10' => TopwireContentObject::NAME,
-            '10.' => [
-                'context' => $context,
-            ],
-        ];
-
-        return $this->validateContentType($request, $handler->handle($request));
-    }
-
-    private function validateContentType(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
-    {
+        $response = $handler->handle($request);
         $contentTypeHeader = $response->getHeaderLine('Content-Type');
         $isStreamResponseAllowed = str_contains($request->getHeaderLine('Accept'), self::turboStreamContentType);
         if ($contentTypeHeader === ''

--- a/ext_typoscript_setup.typoscript
+++ b/ext_typoscript_setup.typoscript
@@ -1,0 +1,7 @@
+topwire = PAGE
+topwire.typeNum = 1745763872
+topwire.config.debug = 0
+topwire.config.disableAllHeaderCode = 1
+topwire.config.disableCharsetHeader = 0
+topwire.10 = TOPWIRE
+topwire.10.context = fromRequest


### PR DESCRIPTION
In order to make transition to TYPO3 v13 more easy code wise the rendering is now done without hacks by transitioning the rendering to a regular page type. When a Topwire Context is detected, the page type is switched to the internal Topwire page type. The rendering middleware now only does consistency checks and the alternative TypoScript with the page type definition is provided statically.

This should be non breaking.
The only side effect is, that default page config is now not picked up by Topwire. The impact of this should be low to non existent.