### PR TITLE
[TASK] Use getAttribute() to retrieve request from rendering context

### DIFF
--- a/Classes/Compatibility/ServerRequestFromRenderingContext.php
+++ b/Classes/Compatibility/ServerRequestFromRenderingContext.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Topwire\Compatibility;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext as FluidRenderingContext;
+
+/**
+ * @deprecated can be removed, when Compatibility to TYPO3 v12 is removed
+ */
+class ServerRequestFromRenderingContext
+{
+    private readonly RenderingContext $renderingContext;
+
+    public function __construct(FluidRenderingContext $renderingContext)
+    {
+        assert($renderingContext instanceof RenderingContext);
+        $this->renderingContext = $renderingContext;
+    }
+
+    public function getRequest(): ServerRequestInterface
+    {
+        if ((new Typo3Version())->getMajorVersion() < 13) {
+            $request = $this->renderingContext->getRequest();
+        } else {
+            $request = $this->renderingContext->getAttribute(ServerRequestInterface::class);
+        }
+        assert($request instanceof ServerRequestInterface);
+        return $request;
+    }
+}

--- a/Classes/Fluid/View/TopwireTemplateView.php
+++ b/Classes/Fluid/View/TopwireTemplateView.php
@@ -2,6 +2,7 @@
 
 namespace Topwire\Fluid\View;
 
+use Topwire\Compatibility\ServerRequestFromRenderingContext;
 use Topwire\Context\Attribute\Section;
 use Topwire\Context\TopwireContext;
 use Topwire\Turbo\Frame;
@@ -15,7 +16,7 @@ class TopwireTemplateView extends AbstractTemplateView
     {
         $renderingContext = $this->getCurrentRenderingContext();
         assert($renderingContext instanceof RenderingContext);
-        $context = $renderingContext->getRequest()?->getAttribute('topwire');
+        $context = (new ServerRequestFromRenderingContext($renderingContext))->getRequest()->getAttribute('topwire');
         if (!$context instanceof TopwireContext) {
             return parent::render($actionName);
         }

--- a/Classes/ViewHelpers/Context/PluginViewHelper.php
+++ b/Classes/ViewHelpers/Context/PluginViewHelper.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace Topwire\ViewHelpers\Context;
 
-use Psr\Http\Message\ServerRequestInterface;
+use Topwire\Compatibility\ServerRequestFromRenderingContext;
 use Topwire\Context\Attribute\Section;
 use Topwire\Context\ContextStack;
 use Topwire\Context\TopwireContextFactory;
@@ -39,8 +39,7 @@ class PluginViewHelper extends AbstractViewHelper
         RenderingContextInterface $renderingContext
     ): string {
         assert($renderingContext instanceof RenderingContext);
-        $request = $renderingContext->getRequest();
-        assert($request instanceof ServerRequestInterface);
+        $request = (new ServerRequestFromRenderingContext($renderingContext))->getRequest();
         $frontendController = $request->getAttribute('frontend.controller');
         assert($frontendController instanceof TypoScriptFrontendController);
         $contextFactory = new TopwireContextFactory(

--- a/Classes/ViewHelpers/Context/RenderViewHelper.php
+++ b/Classes/ViewHelpers/Context/RenderViewHelper.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace Topwire\ViewHelpers\Context;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Topwire\Compatibility\ServerRequestFromRenderingContext;
 use Topwire\ContentObject\TopwireContentObject;
 use Topwire\Context\Attribute\Plugin;
 use Topwire\Context\ContextStack;
@@ -36,8 +37,7 @@ class RenderViewHelper extends AbstractViewHelper
             throw new InvalidTopwireContext('Can only render as child of a Topwire context view helper', 1671623956);
         }
         assert($renderingContext instanceof RenderingContext);
-        $request = $renderingContext->getRequest()?->withAttribute('topwire', $context);
-        assert($request instanceof ServerRequestInterface);
+        $request = (new ServerRequestFromRenderingContext($renderingContext))->getRequest()->withAttribute('topwire', $context);
         $actionRequest = self::addActionNameToRequest(
             $request,
             $context,

--- a/Classes/ViewHelpers/ContextViewHelper.php
+++ b/Classes/ViewHelpers/ContextViewHelper.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace Topwire\ViewHelpers;
 
+use Topwire\Compatibility\ServerRequestFromRenderingContext;
 use Topwire\Context\ContextStack;
 use Topwire\Context\TopwireContextFactory;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
@@ -36,7 +37,7 @@ class ContextViewHelper extends AbstractViewHelper
         RenderingContextInterface $renderingContext
     ): string {
         assert($renderingContext instanceof RenderingContext);
-        $frontendController = $renderingContext->getRequest()?->getAttribute('frontend.controller');
+        $frontendController = (new ServerRequestFromRenderingContext($renderingContext))->getRequest()->getAttribute('frontend.controller');
         assert($frontendController instanceof TypoScriptFrontendController);
         $contextFactory = new TopwireContextFactory(
             $frontendController

--- a/Classes/ViewHelpers/Turbo/FrameViewHelper.php
+++ b/Classes/ViewHelpers/Turbo/FrameViewHelper.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace Topwire\ViewHelpers\Turbo;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Topwire\Compatibility\ServerRequestFromRenderingContext;
 use Topwire\Context\Attribute\Plugin;
 use Topwire\Context\ContextStack;
 use Topwire\Context\TopwireContext;
@@ -61,8 +62,7 @@ class FrameViewHelper extends AbstractViewHelper
         if ($content === null) {
             return $frame->id;
         }
-        $request = $renderingContext->getRequest();
-        assert($request instanceof ServerRequestInterface);
+        $request = (new ServerRequestFromRenderingContext($renderingContext))->getRequest();
 
         return (new FrameRenderer())->render(
             frame: $frame,

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     },
     "require": {
         "php": ">=8.1",
-        "typo3/cms-core": "^11.5.29 || ^12.4.5"
+        "typo3/cms-core": "^11.5.29 || ^12.4.5",
+        "typo3fluid/fluid": "^2.12.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2",

--- a/phpstan-baseline-v11.neon
+++ b/phpstan-baseline-v11.neon
@@ -1,6 +1,16 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Call to function assert\\(\\) with true will always evaluate to true\\.$#"
+			count: 1
+			path: Classes/Compatibility/ServerRequestFromRenderingContext.php
+
+		-
+			message: "#^Instanceof between Psr\\\\Http\\\\Message\\\\ServerRequestInterface and Psr\\\\Http\\\\Message\\\\ServerRequestInterface will always evaluate to true\\.$#"
+			count: 1
+			path: Classes/Compatibility/ServerRequestFromRenderingContext.php
+
+		-
 			message: "#^Call to method getSetupArray\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\TypoScript\\\\FrontendTypoScript\\.$#"
 			count: 1
 			path: Classes/ContentObject/ContentElementWrap.php
@@ -34,11 +44,6 @@ parameters:
 			message: "#^Parameter \\#3 \\$pageId of class Topwire\\\\Context\\\\ContextRecord constructor expects int, int\\|string given\\.$#"
 			count: 3
 			path: Classes/Context/TopwireContextFactory.php
-
-		-
-			message: "#^Using nullsafe method call on non\\-nullable type TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\Request\\. Use \\-\\> instead\\.$#"
-			count: 1
-			path: Classes/Fluid/View/TopwireTemplateView.php
 
 		-
 			message: "#^Method Topwire\\\\Typolink\\\\TopwirePageLinkBuilder\\:\\:build\\(\\) should return TYPO3\\\\CMS\\\\Frontend\\\\Typolink\\\\LinkResultInterface but returns array\\|TYPO3\\\\CMS\\\\Frontend\\\\Typolink\\\\LinkResultInterface\\.$#"
@@ -76,41 +81,6 @@ parameters:
 			path: Classes/ViewHelpers/Context/ContentElementViewHelper.php
 
 		-
-			message: "#^Call to function assert\\(\\) with true will always evaluate to true\\.$#"
-			count: 1
+			message: "#^Parameter \\#1 \\$request of method TYPO3\\\\CMS\\\\Fluid\\\\Core\\\\Rendering\\\\RenderingContext\\:\\:setRequest\\(\\) expects TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\Request, Psr\\\\Http\\\\Message\\\\ServerRequestInterface given\\.$#"
+			count: 2
 			path: Classes/ViewHelpers/Context/PluginViewHelper.php
-
-		-
-			message: "#^Instanceof between TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\Request and Psr\\\\Http\\\\Message\\\\ServerRequestInterface will always evaluate to true\\.$#"
-			count: 1
-			path: Classes/ViewHelpers/Context/PluginViewHelper.php
-
-		-
-			message: "#^Call to function assert\\(\\) with true will always evaluate to true\\.$#"
-			count: 1
-			path: Classes/ViewHelpers/Context/RenderViewHelper.php
-
-		-
-			message: "#^Instanceof between TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\Request and Psr\\\\Http\\\\Message\\\\ServerRequestInterface will always evaluate to true\\.$#"
-			count: 1
-			path: Classes/ViewHelpers/Context/RenderViewHelper.php
-
-		-
-			message: "#^Using nullsafe method call on non\\-nullable type TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\Request\\. Use \\-\\> instead\\.$#"
-			count: 1
-			path: Classes/ViewHelpers/Context/RenderViewHelper.php
-
-		-
-			message: "#^Using nullsafe method call on non\\-nullable type TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\Request\\. Use \\-\\> instead\\.$#"
-			count: 1
-			path: Classes/ViewHelpers/ContextViewHelper.php
-
-		-
-			message: "#^Call to function assert\\(\\) with true will always evaluate to true\\.$#"
-			count: 1
-			path: Classes/ViewHelpers/Turbo/FrameViewHelper.php
-
-		-
-			message: "#^Instanceof between TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\Request and Psr\\\\Http\\\\Message\\\\ServerRequestInterface will always evaluate to true\\.$#"
-			count: 1
-			path: Classes/ViewHelpers/Turbo/FrameViewHelper.php


### PR DESCRIPTION
This API has been backported to older Fluid versions, thus can be used by us already to be future compatible.

But since TYPO3 does not set the the ServerRequest until TYPO3 version 13, a compatibility wrapper class is isntroduced.