### PR TITLE
[BUGFIX] Make title propagation work with Turbo 8

### DIFF
--- a/Classes/ContentObject/ContentElementWrap.php
+++ b/Classes/ContentObject/ContentElementWrap.php
@@ -74,10 +74,12 @@ class ContentElementWrap implements ContentObjectStdWrapHookInterface
         $context = $contextFactory->forPath($path, $record);
         $scopeFrame = (bool)$parentObject->stdWrapValue('scopeFrame', $configuration['turboFrameWrap.'] ?? [], 1);
         $frameId = $parentObject->stdWrapValue('frameId', $configuration['turboFrameWrap.'] ?? [], null);
+        $propagateUrl = (bool)$parentObject->stdWrapValue('propagateUrl', $configuration['turboFrameWrap.'] ?? [], 0);
         $frame = new Frame(
             baseId: (string)($frameId ?? $parentObject->currentRecord),
             wrapResponse: true,
             scope: $scopeFrame ? $context->scope : null,
+            renderFullDocument: $propagateUrl,
         );
         $showWhenFrameMatches = (bool)$parentObject->stdWrapValue('showWhenFrameMatches', $configuration['turboFrameWrap.'] ?? [], false);
         $requestedFrame = $parentObject->getRequest()->getAttribute('topwireFrame');
@@ -95,7 +97,7 @@ class ContentElementWrap implements ContentObjectStdWrapHookInterface
             frame: $frame,
             content: $content,
             options: new FrameOptions(
-                propagateUrl: (bool)$parentObject->stdWrapValue('propagateUrl', $configuration['turboFrameWrap.'] ?? [], 0),
+                propagateUrl: $propagateUrl,
                 morph: (bool)$parentObject->stdWrapValue('morph', $configuration['turboFrameWrap.'] ?? [], 0),
             ),
             context: $scopeFrame ? $context : null,

--- a/Classes/ContentObject/TopwireContentObject.php
+++ b/Classes/ContentObject/TopwireContentObject.php
@@ -3,7 +3,6 @@ namespace Topwire\ContentObject;
 
 use Topwire\Context\TopwireContext;
 use Topwire\Turbo\Frame;
-use Topwire\Turbo\FrameOptions;
 use Topwire\Turbo\FrameRenderer;
 use TYPO3\CMS\Frontend\ContentObject\AbstractContentObject;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -34,15 +33,9 @@ class TopwireContentObject extends AbstractContentObject
             return $content;
         }
 
-        $frameOptions = new FrameOptions();
-        $pageTitle = $this->getTypoScriptFrontendController()->generatePageTitle();
-        if ($pageTitle !== '') {
-            $frameOptions = new FrameOptions(pageTitle: $pageTitle);
-        }
         return (new FrameRenderer())->render(
             frame: $frame,
             content: $content,
-            options: $frameOptions,
             context: $context,
         );
     }

--- a/Classes/Context/TopwireContext.php
+++ b/Classes/Context/TopwireContext.php
@@ -8,6 +8,7 @@ class TopwireContext implements \JsonSerializable
 {
     public const headerName = 'Topwire-Context';
     public const argumentName = 'tx_topwire';
+    public const argumentNameDocument = 'tx_topwire_document';
 
     public readonly string $scope;
     public readonly string $cacheId;

--- a/Classes/Middleware/TopwireContextResolver.php
+++ b/Classes/Middleware/TopwireContextResolver.php
@@ -58,12 +58,16 @@ class TopwireContextResolver implements MiddlewareInterface
                 TopwireContext::argumentName => $cacheId,
             ]
         );
+        $newDynamicArguments = $pageArguments->getDynamicArguments();
+        if ($context?->getAttribute('frame')->renderFullDocument ?? false) {
+            $newDynamicArguments[TopwireContext::argumentNameDocument] = 'true';
+        }
         $modifiedPageArguments = new PageArguments(
             $pageArguments->getPageId(),
             $pageType,
             $pageArguments->getRouteArguments(),
             $newStaticArguments,
-            $pageArguments->getDynamicArguments()
+            $newDynamicArguments
         );
         $request = $request
             ->withAttribute('routing', $modifiedPageArguments)

--- a/Classes/Turbo/Frame.php
+++ b/Classes/Turbo/Frame.php
@@ -13,6 +13,7 @@ class Frame implements Attribute
         public readonly string $baseId,
         public readonly bool $wrapResponse,
         public readonly ?string $scope,
+        public readonly bool $renderFullDocument = false,
     ) {
         $this->id = $baseId
             . ($scope === null ? '' : self::idSeparatorToken . $scope)
@@ -26,9 +27,10 @@ class Frame implements Attribute
     public static function denormalize(array $data, array $context = []): self
     {
         return new Frame(
-            $data['baseId'],
-            $data['wrapResponse'] ?? false,
-            array_key_exists('scope', $data) ? $data['scope'] : $context['context']?->scope,
+            baseId: $data['baseId'],
+            wrapResponse: $data['wrapResponse'] ?? false,
+            scope: array_key_exists('scope', $data) ? $data['scope'] : $context['context']?->scope,
+            renderFullDocument: $data['renderFullDocument'] ?? false,
         );
     }
 
@@ -45,6 +47,9 @@ class Frame implements Attribute
         if ($this->wrapResponse) {
             $data['wrapResponse'] = $this->wrapResponse;
             $data['scope'] = $this->scope;
+        }
+        if ($this->renderFullDocument) {
+            $data['renderFullDocument'] = $this->renderFullDocument;
         }
         return $data;
     }

--- a/Classes/Turbo/FrameOptions.php
+++ b/Classes/Turbo/FrameOptions.php
@@ -13,7 +13,6 @@ class FrameOptions
         public readonly ?string $target = null,
         public readonly bool $propagateUrl = false,
         public readonly bool $morph = false,
-        public readonly ?string $pageTitle = null,
         public readonly array $additionalAttributes = [],
     ) {
     }

--- a/Classes/Turbo/FrameRenderer.php
+++ b/Classes/Turbo/FrameRenderer.php
@@ -26,9 +26,6 @@ class FrameRenderer
         if (isset($options?->target) && $options->target !== '') {
             $tagBuilder->addAttribute('target', $options->target);
         }
-        if (isset($options?->pageTitle) && $options->pageTitle !== '') {
-            $tagBuilder->addAttribute('data-topwire-page-title', $options->pageTitle);
-        }
         if (isset($options?->additionalAttributes) && $options->additionalAttributes !== []) {
             foreach ($options->additionalAttributes as $name => $value) {
                 $tagBuilder->addAttribute($name, $value);

--- a/Classes/ViewHelpers/Turbo/FrameViewHelper.php
+++ b/Classes/ViewHelpers/Turbo/FrameViewHelper.php
@@ -48,6 +48,7 @@ class FrameViewHelper extends AbstractViewHelper
             baseId: $arguments['id'],
             wrapResponse: $arguments['wrapResponse'],
             scope: $context?->scope,
+            renderFullDocument: $arguments['propagateUrl'],
         );
         if (isset($context)) {
             $context = $context->withAttribute('frame', $frame);
@@ -60,15 +61,8 @@ class FrameViewHelper extends AbstractViewHelper
         if ($content === null) {
             return $frame->id;
         }
-        $pageTitle = null;
         $request = $renderingContext->getRequest();
         assert($request instanceof ServerRequestInterface);
-        if ((bool)$arguments['propagateUrl'] && TopwireContext::isRequestSubmitted($request)) {
-            // Handle page title for frames rendered in Fluid templates
-            // @see TopwireContentObject for frames rendered via TypoScript
-            $frontendController = $request->getAttribute('frontend.controller');
-            $pageTitle = $frontendController?->generatePageTitle();
-        }
 
         return (new FrameRenderer())->render(
             frame: $frame,
@@ -78,7 +72,6 @@ class FrameViewHelper extends AbstractViewHelper
                 target: $arguments['target'],
                 propagateUrl: $arguments['propagateUrl'],
                 morph: $arguments['morph'],
-                pageTitle: $pageTitle,
                 additionalAttributes: $arguments['additionalAttributes'],
             ),
             context: $context,

--- a/Resources/Private/JavaScript/turbo-listeners.js
+++ b/Resources/Private/JavaScript/turbo-listeners.js
@@ -30,8 +30,5 @@ document.addEventListener('turbo:before-frame-render', async (event) => {
             }
         }
         render(currentElement, newElement)
-        if (newElement.dataset?.topwirePageTitle && (currentElement.dataset?.turboAction === 'advance' || currentElement.dataset?.turboAction === 'replace')) {
-            document.querySelector('title').innerText = newElement.dataset?.topwirePageTitle
-        }
     }
 })

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -9,6 +9,7 @@ use TYPO3\CMS\Frontend\Typolink\PageLinkBuilder;
 
 (static function (): void {
     $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'tx_topwire';
+    $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'tx_topwire_document';
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['stdWrap']['tx_topwire'] = ContentElementWrap::class;
     if ($GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']['page'] !== PageLinkBuilder::class) {
         $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']['overriddenDefault'] = $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']['page'];

--- a/ext_typoscript_setup.typoscript
+++ b/ext_typoscript_setup.typoscript
@@ -5,3 +5,9 @@ topwire.config.disableAllHeaderCode = 1
 topwire.config.disableCharsetHeader = 0
 topwire.10 = TOPWIRE
 topwire.10.context = fromRequest
+
+[request && request.getPageArguments()?.get('tx_topwire_document') === 'true']
+    topwire.config.disableAllHeaderCode = 0
+    topwire.config.disableCanonical = 1
+    topwire.meta.robots = noindex, follow
+[global]


### PR DESCRIPTION
The title propagation feature implementation was done because Turbo in older versions did NOT do a full page transition for frames even with action="advance" and the title tag being present in the head section of a returned document.

Turbo 8 now does exactly that which is in general good news, because it works as expected, but bad news for our current implementation as this broke, when only a part of the HTML document, the frame, is in the HTML response. Because now an existing title tag in the head section is discarded, making our JS code fail.

To fix this, our own implementation is completely removed in favour of returning a full HTML document now, when the frame requests a full document.